### PR TITLE
Fixes the span customizer signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ services:
 
 ## Span customizers
 
-Span customizers allow the user to add custom information to the span. For example
-by default the span name is being defined by the HTTP verb. This approach is
-a not so bad option seeking for low cardinality in span naming. A more useful
-approach is to use the route path: `/user/{user_id}` however including the 
-`@router` in the middleware is expensive and reduces its performance thus the
-best is to precompile (aka cache warm up) a map of `name => path` in cache that
-can be used to resolve the path in runtime.
+Span customizers allow the user to add custom information to the span based on 
+the request. For example by default the span name is being defined by the HTTP 
+verb. This approach is a not so bad option seeking for low cardinality in span 
+naming. A more useful approach is to use the route path: `/user/{user_id}` however
+including the `@router` in the middleware is expensive and reduces its performance
+thus the best is to precompile (aka cache warm up) a map of `name => path` in cache
+that can be used to resolve the path in runtime.
 
 ```yaml
 services:
@@ -179,7 +179,6 @@ services:
     factory: [ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer, 'create']
     arguments:
       - "%kernel.cache_dir%"
-      - "@request_stack"
 
   zipkin.span_customizer.by_path_namer.cache_warmer:
     class: ZipkinBundle\SpanCustomizers\ByPathNamer\CacheWarmer

--- a/src/ZipkinBundle/Middleware.php
+++ b/src/ZipkinBundle/Middleware.php
@@ -113,7 +113,7 @@ final class Middleware
         }
 
         foreach ($this->spanCustomizers as $customizer) {
-            $customizer($span);
+            $customizer($request, $span);
         }
 
         $routeName = $request->attributes->get('_route');

--- a/src/ZipkinBundle/SpanCustomizer.php
+++ b/src/ZipkinBundle/SpanCustomizer.php
@@ -8,7 +8,9 @@ use Zipkin\Span;
 interface SpanCustomizer
 {
     /**
+     * @param Request $request
      * @param Span $span
+     * @return void
      */
-    public function __invoke(Span $span);
+    public function __invoke(Request $request, Span $span);
 }

--- a/src/ZipkinBundle/SpanCustomizers/ByPathNamer/SpanCustomizer.php
+++ b/src/ZipkinBundle/SpanCustomizers/ByPathNamer/SpanCustomizer.php
@@ -2,6 +2,7 @@
 
 namespace ZipkinBundle\SpanCustomizers\ByPathNamer;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Zipkin\Span;
 use ZipkinBundle\SpanCustomizer as SpanCustomizerInterface;
@@ -15,33 +16,22 @@ final class SpanCustomizer implements SpanCustomizerInterface
      */
     private $routes;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    private function __construct(array $routes, RequestStack $requestStack)
+    private function __construct(array $routes)
     {
         $this->routes = $routes;
-        $this->requestStack = $requestStack;
     }
 
-    public static function create($cacheDir, RequestStack $requestStack)
+    public static function create($cacheDir)
     {
         $routes = @include CacheWarmer::buildOutputFilename($cacheDir);
-        return new self($routes === false ? [] : $routes, $requestStack);
+        return new self($routes === false ? [] : $routes);
     }
 
     /**
      * @inheritdoc
      */
-    public function __invoke(Span $span)
+    public function __invoke(Request $request, Span $span)
     {
-        $request = $this->requestStack->getMasterRequest();
-        if ($request === null) {
-            return;
-        }
-
         $method = $request->getMethod();
         $routeName = $request->attributes->get('_route');
 

--- a/tests/Unit/SpanCustomizers/ByPathNamer/SpanNamerTest.php
+++ b/tests/Unit/SpanCustomizers/ByPathNamer/SpanNamerTest.php
@@ -17,12 +17,10 @@ final class SpanNamerTest extends PHPUnit_Framework_TestCase
 
     public function testGetNameForNonExistingRouteSuccess()
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
         $span = $this->prophesize(Span::class);
         $span->setName('GET not_found')->shouldBeCalled();
-        $naming = SpanCustomizer::create(__DIR__, $requestStack);
-        $naming($span->reveal());
+        $naming = SpanCustomizer::create(__DIR__);
+        $naming(new Request(), $span->reveal());
     }
 
     public function testGetNameForExistingRouteSuccess()
@@ -42,14 +40,12 @@ final class SpanNamerTest extends PHPUnit_Framework_TestCase
             [],
             ['REQUEST_METHOD' => self::METHOD]
         );
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
 
-        $naming = SpanCustomizer::create($cacheDir, $requestStack);
+        $naming = SpanCustomizer::create($cacheDir);
 
         $span = $this->prophesize(Span::class);
         $span->setName(self::METHOD . ' ' . self::ROUTE_PATH)->shouldBeCalled();
-        $naming($span->reveal());
+        $naming($request, $span->reveal());
         unlink($filename);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in the span customizer. The request should be passed explicitly `onTerminate` as the request is gone from `request_stack` by that time.