### PR TITLE
Fix the error tag for when using the status code.

### DIFF
--- a/src/ZipkinBundle/Middleware.php
+++ b/src/ZipkinBundle/Middleware.php
@@ -122,7 +122,7 @@ final class Middleware
 
         $statusCode = $event->getResponse()->getStatusCode();
         if ($statusCode > 399) {
-            $span->tag(Tags\ERROR, $statusCode);
+            $span->tag(Tags\ERROR, (string) $statusCode);
         }
 
         $span->tag(Tags\HTTP_STATUS_CODE, (string) $statusCode);


### PR DESCRIPTION
Tags in zipkin are supposed to be strings.

Ping @UrGuardian4ngel 