### PR TITLE
refactor: improves performance of the library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
           exit $?
 
   symfony-4:
@@ -67,6 +68,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
           exit $?
 
   symfony-5:
@@ -101,6 +103,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
           exit $?
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ jobs:
       - run: |
           # wait just in case
           sleep 1
+          # makes sure we get one trace
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          # makes sure the trace does not contain errors
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 
@@ -67,7 +69,9 @@ jobs:
       - run: |
           # wait just in case
           sleep 1
+          # makes sure we get one trace
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          # makes sure the trace does not contain errors
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 
@@ -102,7 +106,9 @@ jobs:
       - run: |
           # wait just in case
           sleep 1
+          # makes sure we get one trace
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
+          # makes sure the trace does not contain errors
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
-          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 
   symfony-4:
@@ -68,7 +68,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
-          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 
   symfony-5:
@@ -103,7 +103,7 @@ jobs:
           # wait just in case
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 1
-          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0].tags.error') = "null"
+          test $(curl -s 127.0.0.1:9411/api/v2/traces | jq -c '.[0][0].tags.error') = "null"
           exit $?
 
 workflows:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ jobs:
       env: SYMFONY_VERSION=4.4
     - php: "7.3"
       env: SYMFONY_VERSION=4.4
+    - php: "7.1"
+      env: SYMFONY_VERSION=5.0
+    - php: "7.2"
+      env: SYMFONY_VERSION=5.0
+    - php: "7.3"
+      env: SYMFONY_VERSION=5.0
+    - php: "7.4"
+      env: SYMFONY_VERSION=5.0
 
 install:
   - composer require symfony/config:"^$SYMFONY_VERSION" symfony/http-kernel:"^$SYMFONY_VERSION" symfony/routing:"^$SYMFONY_VERSION" symfony/dependency-injection:"^$SYMFONY_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ jobs:
       env: SYMFONY_VERSION=4.4
     - php: "7.3"
       env: SYMFONY_VERSION=4.4
-    - php: "7.1"
-      env: SYMFONY_VERSION=5.0
     - php: "7.2"
       env: SYMFONY_VERSION=5.0
     - php: "7.3"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ services:
       - "@zipkin.default_tracing"
       - "@logger"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }
 ```
 
 `@zipkin.default_tracing` is a `Zipkin\DefaultTracing` instance which is being 
@@ -144,9 +145,10 @@ services:
       - "@logger"
       - { instance: %instance_name% }
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }
 ```
 
 ## Custom Tracing
@@ -163,9 +165,10 @@ services:
       - "@my_own_tracing"
       - "@logger"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }
 ```
 
 ## Span customizers
@@ -201,9 +204,10 @@ services:
       - { instance: %instance_name% }
       - "@zipkin.span_customizer.by_path_namer"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }
 ```
 
 ## Contributing

--- a/src/ZipkinBundle/DependencyInjection/Configuration.php
+++ b/src/ZipkinBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        if (Kernel::VERSION[0] == '5') {
+        if (Kernel::VERSION[0] === '5') {
             $treeBuilder = new TreeBuilder('zipkin');
             $rootNode = $treeBuilder->getRootNode();
         } else {

--- a/tests/Integration/Makefile
+++ b/tests/Integration/Makefile
@@ -1,5 +1,5 @@
-SYMFONY_VERSION ?= dev-master
-LIBRARY_BRANCH ?= 3.0
+SYMFONY_VERSION ?= 4.4
+LIBRARY_BRANCH ?= master
 
 build: ## Builds the symfony app
 	./build.sh $(SYMFONY_VERSION) $(LIBRARY_BRANCH) $(SAMPLER)

--- a/tests/Integration/tracing.custom.yaml
+++ b/tests/Integration/tracing.custom.yaml
@@ -35,6 +35,7 @@ services:
       - { "version": "xxx" }
       - "@zipkin.span_namer.route"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }

--- a/tests/Integration/tracing.default.yaml
+++ b/tests/Integration/tracing.default.yaml
@@ -14,7 +14,7 @@ zipkin:
 services:
   zipkin.span_namer.route:
     class: ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer
-    factory: [ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer, 'create']
+    factory: [ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer, "create"]
     arguments:
       - "%kernel.cache_dir%"
 
@@ -33,6 +33,7 @@ services:
       - { "version": "xxx" }
       - "@zipkin.span_namer.route"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }

--- a/tests/Integration/tracing.percentage.yaml
+++ b/tests/Integration/tracing.percentage.yaml
@@ -12,7 +12,7 @@ zipkin:
 services:
   zipkin.span_namer.route:
     class: ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer
-    factory: [ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer, 'create']
+    factory: [ZipkinBundle\SpanCustomizers\ByPathNamer\SpanCustomizer, "create"]
     arguments:
       - "%kernel.cache_dir%"
 
@@ -31,6 +31,7 @@ services:
       - { "version": "xxx" }
       - "@zipkin.span_namer.route"
     tags:
-      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
-      - { name: kernel.event_listener, event: kernel.terminate }
+      - { name: kernel.event_listener, event: kernel.request, priority: 2560 }
+      - { name: kernel.event_listener, event: kernel.response, priority: -2560 }
       - { name: kernel.event_listener, event: kernel.exception }
+      - { name: kernel.event_listener, event: kernel.terminate }

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Zipkin\Reporters\InMemory as InMemoryReporter;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 final class MiddlewareTest extends TestCase
 {
@@ -181,20 +182,20 @@ final class MiddlewareTest extends TestCase
         $middleware->onKernelRequest($event->reveal());
 
         if (class_exists('Symfony\Component\HttpKernel\Event\PostResponseEvent')) {
-            $responseEvent = new \Symfony\Component\HttpKernel\Event\PostResponseEvent(
+            $terminateEvent = new \Symfony\Component\HttpKernel\Event\PostResponseEvent(
                 $this->mockKernel(),
                 new Request(),
                 new Response()
             );
         } else {
-            $responseEvent = new \Symfony\Component\HttpKernel\Event\TerminateEvent(
+            $terminateEvent = new \Symfony\Component\HttpKernel\Event\TerminateEvent(
                 $this->mockKernel(),
                 new Request(),
                 new Response()
             );
         }
 
-        $middleware->onKernelTerminate($responseEvent);
+        $middleware->onKernelTerminate($terminateEvent);
         $spans = $reporter->flush();
         $this->assertCount(0, $spans);
     }
@@ -207,6 +208,107 @@ final class MiddlewareTest extends TestCase
             [400],
             [500]
         ];
+    }
+
+    /**
+     * @dataProvider statusCodeProvider
+     */
+    public function testSpanIsTaggedOnKernelResponse($responseStatusCode)
+    {
+        $reporter = new InMemoryReporter();
+        $tracing = TracingBuilder::create()
+            ->havingSampler(BinarySampler::createAsAlwaysSample())
+            ->havingReporter($reporter)
+            ->build();
+        $logger = new NullLogger();
+
+        $middleware = new Middleware($tracing, $logger);
+
+        $request = new Request([], [], [], [], [], [
+            'REQUEST_METHOD' => self::HTTP_METHOD,
+            'REQUEST_URI' => self::HTTP_PATH,
+            'HTTP_HOST' => self::HTTP_HOST,
+        ]);
+
+        $event = $this->prophesize(KernelEvent::class);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+
+        $middleware->onKernelRequest($event->reveal());
+
+        if (class_exists('Symfony\Component\HttpKernel\Event\PostResponseEvent')) {
+            $responseEvent = new \Symfony\Component\HttpKernel\Event\FilterResponseEvent(
+                $this->mockKernel(),
+                $request,
+                KernelInterface::MASTER_REQUEST,
+                new Response('', $responseStatusCode)
+            );
+        } else {
+            $responseEvent = new \Symfony\Component\HttpKernel\Event\ResponseEvent(
+                $this->mockKernel(),
+                $request,
+                KernelInterface::MASTER_REQUEST,
+                new Response('', $responseStatusCode)
+            );
+        }
+
+        $middleware->onKernelResponse($responseEvent);
+
+        $assertTags = [
+            'http.host' => self::HTTP_HOST,
+            'http.method' => self::HTTP_METHOD,
+            'http.path' => self::HTTP_PATH,
+            'http.status_code' => (string) $responseStatusCode,
+        ];
+
+        if ($responseStatusCode > 399) {
+            $assertTags['error'] = (string) $responseStatusCode;
+        }
+
+        $tracing->getTracer()->flush();
+        $spans = $reporter->flush();
+        $this->assertCount(1, $spans);
+        $this->assertArraySubset(['tags' => $assertTags], $spans[0]->toArray());
+    }
+
+    public function testSpanScopeIsClosedOnResponse()
+    {
+        $tracing = TracingBuilder::create()
+            ->havingSampler(BinarySampler::createAsAlwaysSample())
+            ->build();
+        $logger = new NullLogger();
+
+        $middleware = new Middleware($tracing, $logger);
+
+        $request = new Request();
+
+        $event = $this->prophesize(KernelEvent::class);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+
+        $middleware->onKernelRequest($event->reveal());
+
+        if (class_exists('Symfony\Component\HttpKernel\Event\PostResponseEvent')) {
+            $responseEvent = new \Symfony\Component\HttpKernel\Event\FilterResponseEvent(
+                $this->mockKernel(),
+                $request,
+                KernelInterface::MASTER_REQUEST,
+                new Response()
+            );
+        } else {
+            $responseEvent = new \Symfony\Component\HttpKernel\Event\ResponseEvent(
+                $this->mockKernel(),
+                $request,
+                KernelInterface::MASTER_REQUEST,
+                new Response()
+            );
+        }
+
+        $this->assertNotNull($tracing->getTracer()->getCurrentSpan());
+
+        $middleware->onKernelResponse($responseEvent);
+
+        $this->assertNull($tracing->getTracer()->getCurrentSpan());
     }
 
     /**

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -364,7 +364,8 @@ final class MiddlewareTest extends TestCase
             $assertTags['error'] = (string) $responseStatusCode;
         }
 
-        $tracing->getTracer()->flush();
+        // There is no need to to `Tracer::flush` here as `onKernelTerminate` does
+        // it already.
         $spans = $reporter->flush();
         $this->assertCount(1, $spans);
         $this->assertArraySubset(['tags' => $assertTags], $spans[0]->toArray());


### PR DESCRIPTION
This PR introduces some improvements in the library:

1. Introduces the `onKernelResponse` listener to have more accurate measurements of request latency.
2. Runs the `flushTracer` on the `onKernelTerminate` listener without the `register_shutdown_function` as this is the symfony idiomatic way to do expensive operations after serving the response (see https://symfony.com/doc/current/reference/events.html#kernel-terminate).
3. Retrieves the tracer and the extractor on construct instead of doing it every time a request comes in. This is no difference in PHP SAPI model but it is an improvement in the event loop model.