### PR TITLE
chore(http-server): improves middleware performance when span is NOOP by not calling the tag methods.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "jcchavezs/httptest": "~0.2",
         "phpunit/phpunit": "^6.5.14",
         "squizlabs/php_codesniffer": "^3.0@dev",
-        "symfony/http-client": "^4.3|^5.0"
+        "symfony/http-client": "^4.4|^5.0"
     },
     "license": "MIT",
     "minimum-stability": "stable",


### PR DESCRIPTION
Following this recommendation, first step towards HTTP Parser is not calling the Span::tag method on NOOP: https://github.com/jcchavezs/zipkin-instrumentation-symfony/pull/65/files#r421168773