### PR TITLE
chore(http-client): renames HttpParser into HttpClientParser.

### DIFF
--- a/src/ZipkinBundle/Components/HttpClient/DefaultHttpClientParser.php
+++ b/src/ZipkinBundle/Components/HttpClient/DefaultHttpClientParser.php
@@ -9,7 +9,7 @@ use const Zipkin\Tags\HTTP_STATUS_CODE;
 use const Zipkin\Tags\ERROR;
 use const Zipkin\Tags\HTTP_RESPONSE_SIZE;
 
-class DefaultHttpParser implements HttpParser
+class DefaultHttpClientParser implements HttpClientParser
 {
     public function request(string $method, string $url, array $options, SpanCustomizer $span): void
     {

--- a/src/ZipkinBundle/Components/HttpClient/HttpClient.php
+++ b/src/ZipkinBundle/Components/HttpClient/HttpClient.php
@@ -35,19 +35,19 @@ final class HttpClient implements HttpClientInterface
     private $injector;
 
     /**
-     * @var HttpParser
+     * @var HttpClientParser
      */
     private $httpParser;
 
     public function __construct(
         HttpClientInterface $client,
         Tracing $tracing,
-        HttpParser $httpParser = null
+        HttpClientParser $httpParser = null
     ) {
         $this->delegate = $client;
         $this->tracer = $tracing->getTracer();
         $this->injector = $tracing->getPropagation()->getInjector(new Map());
-        $this->httpParser = $httpParser ?? new DefaultHttpParser();
+        $this->httpParser = $httpParser ?? new DefaultHttpClientParser();
     }
 
     /**

--- a/src/ZipkinBundle/Components/HttpClient/HttpClientParser.php
+++ b/src/ZipkinBundle/Components/HttpClient/HttpClientParser.php
@@ -4,7 +4,7 @@ namespace ZipkinBundle\Components\HttpClient;
 
 use Zipkin\SpanCustomizer;
 
-interface HttpParser
+interface HttpClientParser
 {
     /**
      * request parses the incoming data related to a request in order to add

--- a/src/ZipkinBundle/Components/HttpClient/README.md
+++ b/src/ZipkinBundle/Components/HttpClient/README.md
@@ -33,7 +33,7 @@ Once declared the zipkin http client as a service you can inject it using the Sy
 
 ## Customizing spans
 
-This client provides a `ZipkinBundle\Components\HttpClient\HttpParser` interface which is used for customizing the tags being added to a span based on the request and the response data.
+This client provides a `ZipkinBundle\Components\HttpClient\HttpClientParser` interface which is used for customizing the tags being added to a span based on the request and the response data.
 
 ```yaml
 services:
@@ -45,14 +45,14 @@ services:
       - "@search_http_parser" # the custom parser
 ```
 
-We also provide a default parser `ZipkinBundle\Components\HttpClient\DefaultHttpParser` which covers the standard cases for HTTP tracing but it can be easily extended to fullfill more advanced cases:
+We also provide a default parser `ZipkinBundle\Components\HttpClient\DefaultHttpClientParser` which covers the standard cases for HTTP tracing but it can be easily extended to fullfill more advanced cases:
 
 ```php
 <?php
 
-use ZipkinBundle\Components\HttpClient\DefaultHttpParser;
+use ZipkinBundle\Components\HttpClient\DefaultHttpClientParser;
 
-final class SearchHttpParser extends DefaultHttpParser {
+final class SearchHttpClientParser extends DefaultHttpClientParser {
     // Additionally to the request standard tags, we add the
     // search key (from the query string with key query) as 
     // a span tag.


### PR DESCRIPTION
Since we are also adding HttpServerParser.