### PR TITLE
chore: prepare for version 3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/routing": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
-        "openzipkin/zipkin": "2.0.x-dev"
+        "openzipkin/zipkin": "2.0.0"
     },
     "require-dev": {
         "jcchavezs/httptest": "~0.2",
@@ -38,10 +38,5 @@
         "test": "./vendor/bin/phpunit tests/Unit",
         "lint": "./vendor/bin/phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* --ignore=*/tests/E2E/test-app/* ./",
         "fix-lint": "./vendor/bin/phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* --ignore=*/tests/Integration/test-app/* ./"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.2.x-dev"
-        }
     }
 }

--- a/src/ZipkinBundle/SpanCustomizer.php
+++ b/src/ZipkinBundle/SpanCustomizer.php
@@ -2,9 +2,12 @@
 
 namespace ZipkinBundle;
 
-use Symfony\Component\HttpFoundation\Request;
 use Zipkin\Span;
+use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprectated
+ */
 interface SpanCustomizer
 {
     /**


### PR DESCRIPTION
This PR uses Zipkin 2.0 in order to release the version 3.0 in this library.