### PR TITLE
fix: fixes the span name by accepting the route on response time.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/routing": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
-        "openzipkin/zipkin": "dev-master"
+        "openzipkin/zipkin": "^2.0.1"
     },
     "require-dev": {
         "jcchavezs/httptest": "~0.2",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/routing": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
-        "openzipkin/zipkin": "2.0.0"
+        "openzipkin/zipkin": "dev-master"
     },
     "require-dev": {
         "jcchavezs/httptest": "~0.2",

--- a/src/ZipkinBundle/KernelListener.php
+++ b/src/ZipkinBundle/KernelListener.php
@@ -223,7 +223,7 @@ final class KernelListener
         $routePath = $this->routeMapper->mapToPath($request);
         if ($response != null) {
             $this->parser->response(
-                new Response($response, new Request($request, $routePath)),
+                new Response($response, new Request($request), $routePath),
                 $span->getContext(),
                 $request->attributes->get(self::SPAN_CUSTOMIZER_KEY)
             );

--- a/src/ZipkinBundle/Response.php
+++ b/src/ZipkinBundle/Response.php
@@ -18,12 +18,19 @@ final class Response extends ServerResponse
      */
     private $request;
 
+    /**
+     * @var string|null
+     */
+    private $route;
+
     public function __construct(
         HttpFoundationResponse $delegate,
-        ?Request $request
+        ?Request $request,
+        string $route = null
     ) {
         $this->delegate = $delegate;
         $this->request = $request;
+        $this->route = $route;
     }
 
     public function getRequest(): ?ServerRequest
@@ -34,6 +41,11 @@ final class Response extends ServerResponse
     public function getStatusCode(): int
     {
         return $this->delegate->getStatusCode();
+    }
+
+    public function getRoute(): ?string
+    {
+        return $this->route;
     }
 
     public function unwrap(): HttpFoundationResponse

--- a/tests/E2E/Makefile
+++ b/tests/E2E/Makefile
@@ -13,6 +13,7 @@ run-app: ## Runs symfony app
 
 run-zipkin: ## Runs zipkin server
 	docker run -d -p 9411:9411 openzipkin/zipkin
+	@echo "\nCheck your traces at http://localhost:9411/zipkin/\n"
 
 clean: ## Cleans build
 	rm -rf test-app

--- a/tests/E2E/test.sh
+++ b/tests/E2E/test.sh
@@ -48,7 +48,7 @@ test $(echo "$TRACES" | jq '.[0] | length') -eq 1
 # makes sure the trace does not contain errors
 test "$(echo "$TRACES" | jq -c '.[0][0].tags.error')" = "null"
 
-# makes sure the span has the right name
+# makes sure the server span has the right name
 test "$(echo "$TRACES" | jq -cr ".[0][0].name")" = "get /_health"
 
 exit $?

--- a/tests/E2E/test.sh
+++ b/tests/E2E/test.sh
@@ -46,6 +46,9 @@ TRACES=$(curl -s $ZIPKIN_SERVER_HOSTPORT/api/v2/traces)
 test $(echo "$TRACES" | jq '.[0] | length') -eq 1
 
 # makes sure the trace does not contain errors
-test $(echo "$TRACES" | jq -c '.[0][0].tags.error') = "null"
+test "$(echo "$TRACES" | jq -c '.[0][0].tags.error')" = "null"
+
+# makes sure the span has the right name
+test "$(echo "$TRACES" | jq -cr ".[0][0].name")" = "get /_health"
 
 exit $?

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -18,10 +18,11 @@ final class ResponseTest extends BaseResponseTest
         int $statusCode,
         $headers = [],
         $body = null,
-        ServerRequest $request = null
+        ServerRequest $request = null,
+        string $route = null
     ): array {
         $delegateResponse = new HttpFoundationResponse($body, $statusCode, $headers);
-        $response = new Response($delegateResponse, $request);
+        $response = new Response($delegateResponse, $request, $route);
         return [$response, $delegateResponse, $request];
     }
 


### PR DESCRIPTION
This PR fixes a regression found by @telemmaite where the route path can't be obtained until the end of the request lifecycle. This feature has been added in https://github.com/openzipkin/zipkin-php/pull/180